### PR TITLE
fix: set primary key as string

### DIFF
--- a/src/Models/City.php
+++ b/src/Models/City.php
@@ -11,6 +11,10 @@ class City extends Model
 {
     protected $primaryKey = 'code';
 
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
     protected $fillable = [
         'code', 'province_code', 'name', 'latitude', 'longitude',
     ];

--- a/src/Models/District.php
+++ b/src/Models/District.php
@@ -11,6 +11,10 @@ class District extends Model
 {
     protected $primaryKey = 'code';
 
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
     protected $fillable = [
         'code', 'city_code', 'name', 'latitude', 'longitude',
     ];

--- a/src/Models/Province.php
+++ b/src/Models/Province.php
@@ -14,6 +14,10 @@ class Province extends Model
 
     protected $primaryKey = 'code';
 
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
     protected $fillable = [
         'code', 'name', 'latitude', 'longitude',
     ];

--- a/src/Models/Village.php
+++ b/src/Models/Village.php
@@ -14,6 +14,10 @@ class Village extends Model
 
     protected $primaryKey = 'code';
 
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
     protected $fillable = [
         'code', 'district_code', 'name', 'latitude', 'longitude', 'postal_code',
     ];

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -39,7 +39,7 @@ it('can get a province', function () {
     expect(Province::first())->not->toBeEmpty();
 
     $province = Province::find(33);
-    expect($province->code)->toBe(33);
+    expect($province->code)->toBe('33');
     expect($province->name)->toBe('JAWA TENGAH');
     expect($province->latitude)->toBe('-7.150975');
     expect($province->longitude)->toBe('110.1402594');
@@ -49,25 +49,25 @@ it('can get province model relations', function () {
     $cities = Province::find(33)->cities;
     expect($cities)->toBeInstanceOf(Collection::class);
     expect($cities->count())->toBe(35);
-    expect($cities->first()->code)->toBe(3301);
+    expect($cities->first()->code)->toBe('3301');
     expect($cities->first()->name)->toBe('KABUPATEN CILACAP');
-    expect($cities->last()->code)->toBe(3376);
+    expect($cities->last()->code)->toBe('3376');
     expect($cities->last()->name)->toBe('KOTA TEGAL');
 
     $districts = Province::find(33)->districts;
     expect($districts)->toBeInstanceOf(Collection::class);
     expect($districts->count())->toBe(576);
-    expect($districts->first()->code)->toBe(330101);
+    expect($districts->first()->code)->toBe('330101');
     expect($districts->first()->name)->toBe('KEDUNGREJA');
-    expect($districts->last()->code)->toBe(337604);
+    expect($districts->last()->code)->toBe('337604');
     expect($districts->last()->name)->toBe('MARGADANA');
 
     $villlages = Province::find(33)->villages;
     expect($villlages)->toBeInstanceOf(Collection::class);
     expect($villlages->count())->toBe(8562);
-    expect($villlages->first()->code)->toBe(3301012001);
+    expect($villlages->first()->code)->toBe('3301012001');
     expect($villlages->first()->name)->toBe('TAMBAKREJA');
-    expect($villlages->last()->code)->toBe(3376041007);
+    expect($villlages->last()->code)->toBe('3376041007');
     expect($villlages->last()->name)->toBe('PESURUNGAN LOR');
 });
 
@@ -75,7 +75,7 @@ it('can get a city', function () {
     expect(City::first())->not->toBeEmpty();
 
     $city = City::find(3374);
-    expect($city->code)->toBe(3374);
+    expect($city->code)->toBe('3374');
     expect($city->name)->toBe('KOTA SEMARANG');
     expect($city->latitude)->toBe('-7.0051453');
     expect($city->longitude)->toBe('110.4381254');
@@ -84,23 +84,23 @@ it('can get a city', function () {
 it('can get city model relations', function () {
     $province = City::find(3374)->province;
     expect($province)->toBeInstanceOf(Province::class);
-    expect($province->code)->toBe(33);
+    expect($province->code)->toBe('33');
     expect($province->name)->toBe('JAWA TENGAH');
 
     $districts = City::find(3374)->districts;
     expect($districts)->toBeInstanceOf(Collection::class);
     expect($districts->count())->toBe(16);
-    expect($districts->first()->code)->toBe(337401);
+    expect($districts->first()->code)->toBe('337401');
     expect($districts->first()->name)->toBe('SEMARANG TENGAH');
-    expect($districts->last()->code)->toBe(337416);
+    expect($districts->last()->code)->toBe('337416');
     expect($districts->last()->name)->toBe('TUGU');
 
     $cities = City::find(3374)->villages;
     expect($cities)->toBeInstanceOf(Collection::class);
     expect($cities->count())->toBe(177);
-    expect($cities->first()->code)->toBe(3374011001);
+    expect($cities->first()->code)->toBe('3374011001');
     expect($cities->first()->name)->toBe('MIROTO');
-    expect($cities->last()->code)->toBe(3374161007);
+    expect($cities->last()->code)->toBe('3374161007');
     expect($cities->last()->name)->toBe('MANGUNHARJO');
 });
 
@@ -108,7 +108,7 @@ it('can get a district', function () {
     expect(District::first())->not->toBeEmpty();
 
     $district = District::find(337401);
-    expect($district->code)->toBe(337401);
+    expect($district->code)->toBe('337401');
     expect($district->name)->toBe('SEMARANG TENGAH');
     expect($district->latitude)->toBe('-6.9805495');
     expect($district->longitude)->toBe('110.4202505');
@@ -117,20 +117,20 @@ it('can get a district', function () {
 it('can get district model relations', function () {
     $province = District::find(337401)->province;
     expect($province)->toBeInstanceOf(Province::class);
-    expect($province->code)->toBe(33);
+    expect($province->code)->toBe('33');
     expect($province->name)->toBe('JAWA TENGAH');
 
     $city = District::find(337401)->city;
     expect($city)->toBeInstanceOf(City::class);
-    expect($city->code)->toBe(3374);
+    expect($city->code)->toBe('3374');
     expect($city->name)->toBe('KOTA SEMARANG');
 
     $villlages = District::find(337401)->villages;
     expect($villlages)->toBeInstanceOf(Collection::class);
     expect($villlages->count())->toBe(15);
-    expect($villlages->first()->code)->toBe(3374011001);
+    expect($villlages->first()->code)->toBe('3374011001');
     expect($villlages->first()->name)->toBe('MIROTO');
-    expect($villlages->last()->code)->toBe(3374011015);
+    expect($villlages->last()->code)->toBe('3374011015');
     expect($villlages->last()->name)->toBe('PINDRIKAN LOR');
 });
 
@@ -138,7 +138,7 @@ it('can get a village', function () {
     expect(Village::first())->not->toBeEmpty();
 
     $village = Village::find(3374011001);
-    expect($village->code)->toBe(3374011001);
+    expect($village->code)->toBe('3374011001');
     expect($village->name)->toBe('MIROTO');
     expect($village->latitude)->toBe('-6.9837576');
     expect($village->longitude)->toBe('110.4195057');
@@ -147,29 +147,29 @@ it('can get a village', function () {
 it('can get village model relations', function () {
     $province = Village::find(3374011001)->province;
     expect($province)->toBeInstanceOf(Province::class);
-    expect($province->code)->toBe(33);
+    expect($province->code)->toBe('33');
     expect($province->name)->toBe('JAWA TENGAH');
 
     $city = Village::find(3374011001)->city;
     expect($city)->toBeInstanceOf(City::class);
-    expect($city->code)->toBe(3374);
+    expect($city->code)->toBe('3374');
     expect($city->name)->toBe('KOTA SEMARANG');
 
     $district = Village::find(3374011001)->district;
     expect($district)->toBeInstanceOf(District::class);
-    expect($district->code)->toBe(337401);
+    expect($district->code)->toBe('337401');
     expect($district->name)->toBe('SEMARANG TENGAH');
 });
 
 it('can get new districts added in v2', function () {
     $district = District::find(110115);
-    expect($district->code)->toBe(110115);
+    expect($district->code)->toBe('110115');
     expect($district->name)->toBe('BAKONGAN TIMUR');
     expect($district->latitude)->toBe('NULL');
     expect($district->longitude)->toBe('NULL');
 
     $district = District::find(911823);
-    expect($district->code)->toBe(911823);
+    expect($district->code)->toBe('911823');
     expect($district->name)->toBe('KOROWAY BULUANOP');
     expect($district->latitude)->toBe('NULL');
     expect($district->longitude)->toBe('NULL');
@@ -177,13 +177,13 @@ it('can get new districts added in v2', function () {
 
 it('can get new villages added in v2', function () {
     $village = Village::find(1207212002);
-    expect($village->code)->toBe(1207212002);
+    expect($village->code)->toBe('1207212002');
     expect($village->name)->toBe('PATUMBAK I');
     expect($village->latitude)->toBe('NULL');
     expect($village->longitude)->toBe('NULL');
 
     $village = Village::find(9201502009);
-    expect($village->code)->toBe(9201502009);
+    expect($village->code)->toBe('9201502009');
     expect($village->name)->toBe('MLARON');
     expect($village->latitude)->toBe('NULL');
     expect($village->longitude)->toBe('NULL');
@@ -191,7 +191,7 @@ it('can get new villages added in v2', function () {
 
 it('can test new data for v2.0.2', function () {
     $district = District::find(331710);
-    expect($district->code)->toBe(331710);
+    expect($district->code)->toBe('331710');
     expect($district->name)->toBe('REMBANG');
     expect($district->latitude)->toBe('-6.7147586');
     expect($district->longitude)->toBe('111.3281411');


### PR DESCRIPTION
When eager loading relationship using PostgreSQL, like this `Outlet::with('district')->first()`, the following error occured:

```
Illuminate\Database\QueryException  SQLSTATE[42883]: Undefined function: 7 ERROR:  operator does not exist: character = integer
LINE 1: ...sia_districts" where "indonesia_districts"."code" in (352314...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts. (Connection: pgsql, SQL: select * from "indonesia_districts" where "indonesia_districts"."code" in (352314)).
```

After configuring the model primary key as string resolve the issue.

Reference: https://laravel.com/docs/11.x/eloquent#primary-keys